### PR TITLE
[Feat] add preprocessing tools on retrieval

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,10 +34,10 @@ data:
   use_faiss : False
   use_sub: False
   use_normalize: False
-  drop_duplicated_wiki: True
-  drop_less_than_50_percent_of_korean: True
-  drop_too_long_text: True
-  add_title_to_text: True
+  use_drop_duplicated_wiki: True
+  use_drop_less_than_50_percent_of_korean: True
+  use_drop_too_long_text: True
+  use_add_title_to_text: True
 
 sweepcnt : 2 # sweep을 반복할 횟수(체크포인트 용량으로 인해 30이하 권장)
 sweep:

--- a/utils/Retrieval.py
+++ b/utils/Retrieval.py
@@ -28,9 +28,10 @@ class SparseRetrieval:
         context_path: Optional[str] = "wikipedia_documents.json",
         use_normalize = False,
         use_sub = False,
-        drop_duplicated_wiki= False,
-        drop_less_than_50_percent_of_korean= False,
-        drop_too_long_text = False
+        use_drop_duplicated_wiki= False,
+        use_drop_less_than_50_percent_of_korean= False,
+        use_drop_too_long_text = False,
+        use_add_title_to_text = False
     ) -> None:
 
         """
@@ -60,13 +61,13 @@ class SparseRetrieval:
         
         
         
-        if drop_duplicated_wiki: # 위키피디아 text 중복 제거
+        if use_drop_duplicated_wiki: # 위키피디아 text 중복 제거
             wiki = drop_duplicated_wiki(wiki)
-        if drop_less_than_50_percent_of_korean: # 위키피디아 text에서 한글비중 50%이하 제거
+        if use_drop_less_than_50_percent_of_korean: # 위키피디아 text에서 한글비중 50%이하 제거
             wiki = drop_less_than_50_percent_of_korean(wiki)
-        if drop_too_long_text: # 위키피다아 text 길이 가장 긴 상위 1% 제거
+        if use_drop_too_long_text: # 위키피다아 text 길이 가장 긴 상위 1% 제거
             wiki = drop_too_long_text(wiki)
-        if add_title_to_text: # 검색능력 향상을 위해 title을 text 앞에 붙이기
+        if use_add_title_to_text: # 검색능력 향상을 위해 title을 text 앞에 붙이기
             wiki = add_title_to_text(wiki)
             
 

--- a/utils/bm25.py
+++ b/utils/bm25.py
@@ -34,10 +34,10 @@ class BM25Retrieval:
         stage = 'predict',
         use_normalize = False,
         use_sub = False,
-        drop_duplicated_wiki= False,
-        drop_less_than_50_percent_of_korean= False,
-        drop_too_long_text = False,
-        add_title_to_text = False
+        use_drop_duplicated_wiki= False,
+        use_drop_less_than_50_percent_of_korean= False,
+        use_drop_too_long_text = False,
+        use_add_title_to_text = False
     ) -> None:
         
         self.stage = stage
@@ -45,13 +45,13 @@ class BM25Retrieval:
         with open(os.path.join(data_path, context_path), "r", encoding="utf-8") as f:
             wiki = json.load(f)
             
-        if drop_duplicated_wiki: # 위키피디아 text 중복 제거
+        if use_drop_duplicated_wiki: # 위키피디아 text 중복 제거
             wiki = drop_duplicated_wiki(wiki)
-        if drop_less_than_50_percent_of_korean: # 위키피디아 text에서 한글비중 50%이하 제거
+        if use_drop_less_than_50_percent_of_korean: # 위키피디아 text에서 한글비중 50%이하 제거
             wiki = drop_less_than_50_percent_of_korean(wiki)
-        if drop_too_long_text: # 위키피다아 text 길이 가장 긴 상위 1% 제거
+        if use_drop_too_long_text: # 위키피다아 text 길이 가장 긴 상위 1% 제거
             wiki = drop_too_long_text(wiki)
-        if add_title_to_text: # 검색능력 향상을 위해 title을 text 앞에 붙이기
+        if use_add_title_to_text: # 검색능력 향상을 위해 title을 text 앞에 붙이기
             wiki = add_title_to_text(wiki)
 
         self.contexts = list(

--- a/utils/preprocess.py
+++ b/utils/preprocess.py
@@ -136,7 +136,7 @@ def drop_too_long_text(
         df['length'] = df['text'].apply(lambda x:len(re.sub(r'[\n\s]','', x)))
         df['length_qcut'] = pd.qcut(df['length'],100, labels=range(100))
         drop_index = df[df['length_qcut'] == 99].index
-        drop_too_long_df = df.drop(drop_index).drop(labels=['length', 'length_qcut'])
+        drop_too_long_df = df.drop(drop_index).drop(labels=['length', 'length_qcut'], axis=1)
         new_wiki = drop_too_long_df.to_dict('index')
         
         return new_wiki

--- a/utils/utils_retrieval.py
+++ b/utils/utils_retrieval.py
@@ -76,10 +76,10 @@ def run_bm25(stage, config,
         stage=stage, 
         use_normalize=config['data']['use_normalize'], 
         use_sub=config['data']['use_sub'],
-        drop_duplicated_wiki = config['data']['drop_duplicated_wiki'],
-        drop_less_than_50_percent_of_korean = config['data']['drop_less_than_50_percent_of_korean'],
-        drop_too_long_text = config['data']['drop_too_long_text'],
-        add_title_to_text = config['data']['add_title_to_text']
+        use_drop_duplicated_wiki = config['data']['use_drop_duplicated_wiki'],
+        use_drop_less_than_50_percent_of_korean = config['data']['use_drop_less_than_50_percent_of_korean'],
+        use_drop_too_long_text = config['data']['use_drop_too_long_text'],
+        use_add_title_to_text = config['data']['use_add_title_to_text']
     )
     retriever.get_bm25()
     


### PR DESCRIPTION
# Feat Preprocess
- preproecess.py에 새로운 기능 추가
- wikipedia text 중복 제거
- wikipedia text 한글 비중 50% 이하 제거
- wikipedia text 길이 가장 긴 상위 1% 제거
- wikipedia title를 text 앞에 붙임. 검색 능력 향상 위해.

# 사용 방법
- config.yaml 파일에서 다음 중 원하는 것 True로 바꾸기
```
use_drop_duplicated_wiki: True
use_drop_less_than_50_percent_of_korean: True
use_drop_too_long_text: True
use_add_title_to_text: True

```